### PR TITLE
small fixes to make plugin work better in ysfx

### DIFF
--- a/EQ-A4k/mawi_EQ-A4k.jsfx
+++ b/EQ-A4k/mawi_EQ-A4k.jsfx
@@ -1042,6 +1042,7 @@ high_cut_frequency.slider_parameter_log_scaled_(27, slider_high_cut_frequency, 1
 phase_inv.slider_parameter_(29, slider_phase_inv, 1, 0, 1, 1);
 
 @gfx 960 240
+gfx_a = 1.0;
 background_color_(25, 26, 27);
 background_img_(0, 0);
 

--- a/EQ-A4k/mawi_EQ-A4k.jsfx
+++ b/EQ-A4k/mawi_EQ-A4k.jsfx
@@ -69,6 +69,34 @@ slider27:slider_high_cut_frequency=16000<300,16000,0.01,:log=3000>-LPF Freq (Hz)
 // slider28:
 slider29:slider_phase_inv=0<0,1,1{Normal,Inverted}>-Phase
 
+filename:0,img/background.png
+filename:1,img/poti_low_gain.png
+filename:2,img/poti_low_freq.png
+filename:3,img/poti_low_q.png
+filename:4,img/button_low_type.png
+filename:5,img/poti_hpf.png
+filename:6,img/poti_low_mid_gain.png
+filename:7,img/poti_low_mid_freq.png
+filename:8,img/poti_low_mid_q.png
+filename:9,img/poti_trim.png
+filename:10,img/poti_high_mid_gain.png
+filename:11,img/poti_high_mid_freq.png
+filename:12,img/poti_high_mid_q.png
+filename:13,img/poti_high_gain.png
+filename:14,img/poti_high_freq.png
+filename:15,img/poti_high_q.png
+filename:16,img/poti_lpf.png
+filename:17,img/button_high_type.png
+filename:18,img/button_bypass.png
+filename:19,img/button_hpf1.png
+filename:20,img/button_hpf2.png
+filename:21,img/button_hpf3.png
+filename:22,img/button_lpf1.png
+filename:23,img/button_lpf2.png
+filename:24,img/button_lpf3.png
+filename:25,img/button_phase.png
+filename:26,img/menu.png
+
 options:no_meter
 
 @serialize
@@ -79,34 +107,6 @@ file_var(0, _global.mawi_eq_a4k_auto_bypass_on_stop);
 @init
 ext_tail_size = -1;
 gfx_ext_retina = 1;
-
-gfx_loadimg(0, "./img/background.png");
-gfx_loadimg(1, "./img/poti_low_gain.png");
-gfx_loadimg(2, "./img/poti_low_freq.png");
-gfx_loadimg(3, "./img/poti_low_q.png");
-gfx_loadimg(4, "./img/button_low_type.png");
-gfx_loadimg(5, "./img/poti_hpf.png");
-gfx_loadimg(6, "./img/poti_low_mid_gain.png");
-gfx_loadimg(7, "./img/poti_low_mid_freq.png");
-gfx_loadimg(8, "./img/poti_low_mid_q.png");
-gfx_loadimg(9, "./img/poti_trim.png");
-gfx_loadimg(10, "./img/poti_high_mid_gain.png");
-gfx_loadimg(11, "./img/poti_high_mid_freq.png");
-gfx_loadimg(12, "./img/poti_high_mid_q.png");
-gfx_loadimg(13, "./img/poti_high_gain.png");
-gfx_loadimg(14, "./img/poti_high_freq.png");
-gfx_loadimg(15, "./img/poti_high_q.png");
-gfx_loadimg(16, "./img/poti_lpf.png");
-gfx_loadimg(17, "./img/button_high_type.png");
-gfx_loadimg(18, "./img/button_bypass.png");
-gfx_loadimg(19, "./img/button_hpf1.png");
-gfx_loadimg(20, "./img/button_hpf2.png");
-gfx_loadimg(21, "./img/button_hpf3.png");
-gfx_loadimg(22, "./img/button_lpf1.png");
-gfx_loadimg(23, "./img/button_lpf2.png");
-gfx_loadimg(24, "./img/button_lpf3.png");
-gfx_loadimg(25, "./img/button_phase.png");
-gfx_loadimg(26, "./img/menu.png");
 
 degrees = $pi/180;
 


### PR DESCRIPTION
First of all, nice work on these gorgeous plugins. They are some of the prettiest EQs I've seen.

I noticed two things in this plugin that limit its use in `ysfx`, so I thought I'd open a small PR with some minor suggestions (these probably also apply to some of the other plugins in the repo). Feel free to close/ignore it if you have no time for this or don't want to make the changes.

#### 1. You load graphics in `@init` with `gfx_loadimg`. This is not really recommended.

![image](https://github.com/user-attachments/assets/f49cb420-9372-4058-b5b9-614bce50fdb3)

In `jsfx` that seems to behave fine-ish (although, if you do a "full recompile" in the JSFX editor, you will see the plugin come up blank the second time, which makes me think that even there the implementation is not 100% foolproof).

In `ysfx` it is a bit worse though. `ysfx` doesn't cache the images the same way reaper does. So putting them in `@init` forces a full reload every time you press play (which for 50 mb of images can be pretty slow). I'll probably look into doing something similar, but for the time being, you could work around it as follows (if you want to):

A. You declare the files you're gonna be blitting at the top with `filename` (see the suggestion in this PR). 
B. Or you load them in `@gfx` the first time `@gfx` runs. Something like:

```c
(!loaded) ? (
  loaded = 1;
  // Load my stuff
);
```
Either of these two ways is fully supported by both `jsfx` and `ysfx` and afaik, does not lead to the same stalling behavior in JSFX.

#### 2. You don't reset alpha at the start of `@gfx`

You don't reset `gfx_a` at the start of the `@gfx` loop which makes it render semi-transparently in `ysfx`. I think it carries over from `resize_icon_` over to the next cycle. It seems `jsfx` resets this automatically for you, but that's something `ysfx` does not yet do.

Anyways, just some suggestions. Up to you what you want to do with them!